### PR TITLE
Chapter 10 name servo helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ debug_data
 .vscode
 .env.js
 pyinfra-debug.log
+.ipynb_checkpoints

--- a/robot/inventor_hat_service.py
+++ b/robot/inventor_hat_service.py
@@ -23,17 +23,24 @@ def all_messages(client, userdata, msg):
 def set_servo_position(servo, client, userdata, msg, fine_tune=0):
     try:
         position = float(msg.payload) + fine_tune
-        # servo.enable()
         servo.value(position)
     except OSError:
         print("Error: Failed to set servo position")
     except ValueError:
         print("Error: Invalid position value")
+set_pan = partial(set_servo_position, pan, fine_tune=5)
+set_pan.__name__ = "set_pan"
+set_tilt = partial(set_servo_position, tilt, fine_tune=0)
+set_tilt.__name__ = "set_tilt"
 
 
 def stop_servo(servo, client=None, userdata=None, msg=None):
     if servo.is_enabled():
         servo.disable()
+stop_pan = partial(stop_servo, pan)
+stop_pan.__name__ = "stop_pan"
+stop_tilt = partial(stop_servo, tilt)
+stop_tilt.__name__ = "stop_tilt"
 
 
 def set_motor_wheels(client, userdata, msg):
@@ -47,8 +54,8 @@ def set_motor_wheels(client, userdata, msg):
 def stop_motors(client=None, userdata=None, msg=None):
     left_motor.stop()
     right_motor.stop()
-    stop_servo(pan)
-    stop_servo(tilt)
+    stop_pan()
+    stop_tilt()
 
 
 def on_connect(client, userdata, flags, rc):
@@ -75,16 +82,10 @@ client.on_connect = on_connect
 client.message_callback_add("motors/#", all_messages)
 client.message_callback_add("motors/stop", stop_motors)
 client.message_callback_add("motors/wheels", set_motor_wheels)
-client.message_callback_add("motors/servo/pan/position",
-                            partial(set_servo_position, pan,
-                                    fine_tune=5))
-client.message_callback_add("motors/servo/pan/stop",
-                            partial(stop_servo, pan))
-client.message_callback_add("motors/servo/tilt/position",
-                            partial(set_servo_position, tilt,
-                                    fine_tune=0))
-client.message_callback_add("motors/servo/tilt/stop",
-                            partial(stop_servo, tilt))
+client.message_callback_add("motors/servo/pan/position", set_pan)
+client.message_callback_add("motors/servo/pan/stop", stop_pan)
+client.message_callback_add("motors/servo/tilt/position", set_tilt)
+client.message_callback_add("motors/servo/tilt/stop", stop_tilt)
 client.message_callback_add("all/stop", stop_motors)
 client.message_callback_add("all/#", all_messages)
 


### PR DESCRIPTION
Naming the servo helpers helps in two ways:
- This makes tracebacks more readable for troubleshooting
- It makes the code using the helpers simpler for the readers

This will require manuscript updates (in a supplemental) too